### PR TITLE
Upgrade node version used in C.I

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [14]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
With the lib upgrades implemented in #4 , it is required to upgrade Node version to v14 in github actions.